### PR TITLE
#152883905 Create template page for users to see all centers

### DIFF
--- a/template/centers2.html
+++ b/template/centers2.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+
+<head>
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="css/font-awesome.min.css">
+  <link rel="stylesheet" href="css/bootstrap.css">
+  <link rel="stylesheet" href="css/centers2.css">
+  <title>Ievents</title>
+</head>
+
+<body>
+  <div class="d-block">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-lg-2 fixed-top" id="navigation-section">
+          <div class="profile-pic mt-5 text-center">
+            <img src="img/person.jpeg" alt="" class="img-round">
+            <p class="lead text-white pt-3" id="userName">Tunmise Ogunniyi</p>
+          </div>
+          <div class="pt-3 navigation-links">
+            <div class="list-group">
+              <a class="list-group-item" href="#">
+                <i class="fa fa-user-circle fa-fw" aria-hidden="true"></i>&nbsp; My Events</a>
+              <a class="list-group-item" href="#">
+                <i class="fa fa-plus fa-fw" aria-hidden="true"></i>&nbsp; Add Events</a>
+              <a class="list-group-item" href="#content-section">
+                <i class="fa fa-bank fa-fw" aria-hidden="true"></i>&nbsp; Centers</a>
+              <a class="list-group-item" href="#">
+                <i class="fa fa-envelope fa-fw" aria-hidden="true"></i>&nbsp; Messages</a>
+              <a class="list-group-item" href="#">
+                <i class="fa fa-history fa-fw" aria-hidden="true"></i>&nbsp; History</a>
+              <a class="list-group-item" href="#">
+                <i class="fa fa-user fa-fw" aria-hidden="true"></i>&nbsp; Profile</a>
+              <a class="list-group-item" href="#">
+                <i class="fa fa-power-off fa-fw" aria-hidden="true"></i>&nbsp; Logout</a>
+            </div>
+          </div>
+        </div>
+        
+        <div class="col-lg-10 offset-md-2" id="content-section">
+            <section id="centers-section">
+                <div class="container">
+                  <div id="center-section-content" class="d-flex flex-column align-items-center">
+                    <div id="center-section-header">
+                      <h1 class="display-4">A special center for a special event</h1>
+                    </div>
+                    <div class="search-box input-group w-50 mt-5">
+                      <input type="text" class="form-control" placeholder="Search for a center">
+                      <div class="input-group-btn d-none d-sm-block">
+                        <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                          Search with
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right">
+                          <a class="dropdown-item" href="#">Location</a>
+                          <div role="separator" class="dropdown-divider"></div>
+                          <a class="dropdown-item" href="#">Name</a>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="search-box mt-3 d-block d-sm-none">
+                      <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                        Search with
+                      </button>
+                      <div class="dropdown-menu">
+                        <a class="dropdown-item" href="#">Location</a>
+                        <div role="separator" class="dropdown-divider"></div>
+                        <a class="dropdown-item" href="#">Name</a>
+                      </div>
+                    </div>        
+                  </div>
+                  <!-- Grid view -->
+                  <div class="mt-5">
+                    <div class="row">
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-lg-4 col-md-6 col-sm-12">
+                        <div class="card">
+                          <div>
+                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                          </div>
+                          <div class="card-body d-flex flex-column">
+                            <div>
+                              <h4 class="card-title">Ottawa event center</h4>
+                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                            </div>
+                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- Pagination  -->
+                  <div class="mt-3">
+                    <ul class="pagination justify-content-center">
+                      <li class="page-item">
+                        <a href="" class="page-link">
+                          <i class="fa fa-angle-left"></i>
+                        </a>
+                      </li>
+                      <li class="page-item active">
+                        <a href="" class="page-link">1</a>
+            
+                      </li>
+                      <li class="page-item">
+                        <a href="" class="page-link">2</a>
+            
+                      </li>
+                      <li class="page-item">
+                        <a href="" class="page-link">3</a>
+                      </li>
+                      <li class="page-item">
+                        <a href="" class="page-link">4</a>
+                      </li>
+                      <li class="page-item">
+                        <a href="" class="page-link">5</a>
+                      </li>
+                      <li class="page-item">
+                        <a href="" class="page-link">
+                          <i class="fa fa-angle-right"></i>
+                        </a>
+                        </i>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                
+              </section>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+
+
+  <script src="js/jquery.min.js"></script>
+  <script src="js/popper.min.js"></script>
+  <script src="js/bootstrap.min.js"></script>
+</body>
+
+</html>

--- a/template/centers2.html
+++ b/template/centers2.html
@@ -38,224 +38,229 @@
             </div>
           </div>
         </div>
-        
+
         <div class="col-lg-10 offset-md-2" id="content-section">
-            <section id="centers-section">
-                <div class="container">
-                  <div id="center-section-content" class="d-flex flex-column align-items-center">
-                    <div id="center-section-header">
-                      <h1 class="display-4">A special center for a special event</h1>
+          <nav class="navbar w-100 bg-white">
+            <a class="navbar-brand text-dark" href="#">
+              <strong>Centers</strong>
+            </a>
+          </nav>
+          <section id="centers-section">
+            <div class="container">
+              <div id="center-section-content" class="d-flex flex-column align-items-center">
+                <div id="center-section-header">
+                  <h1 class="display-4">A special center for a special event</h1>
+                </div>
+                <div class="search-box input-group w-50 mt-5">
+                  <input type="text" class="form-control" placeholder="Search for a center">
+                  <div class="input-group-btn d-none d-sm-block">
+                    <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                      Search with
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right">
+                      <a class="dropdown-item" href="#">Location</a>
+                      <div role="separator" class="dropdown-divider"></div>
+                      <a class="dropdown-item" href="#">Name</a>
                     </div>
-                    <div class="search-box input-group w-50 mt-5">
-                      <input type="text" class="form-control" placeholder="Search for a center">
-                      <div class="input-group-btn d-none d-sm-block">
-                        <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
-                          Search with
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right">
-                          <a class="dropdown-item" href="#">Location</a>
-                          <div role="separator" class="dropdown-divider"></div>
-                          <a class="dropdown-item" href="#">Name</a>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="search-box mt-3 d-block d-sm-none">
-                      <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
-                        Search with
-                      </button>
-                      <div class="dropdown-menu">
-                        <a class="dropdown-item" href="#">Location</a>
-                        <div role="separator" class="dropdown-divider"></div>
-                        <a class="dropdown-item" href="#">Name</a>
-                      </div>
-                    </div>        
-                  </div>
-                  <!-- Grid view -->
-                  <div class="mt-5">
-                    <div class="row">
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-lg-4 col-md-6 col-sm-12">
-                        <div class="card">
-                          <div>
-                            <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
-                            <span class="badge text-white p-2 seat-badge ">4000 seat</span>
-                          </div>
-                          <div class="card-body d-flex flex-column">
-                            <div>
-                              <h4 class="card-title">Ottawa event center</h4>
-                              <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
-                            </div>
-                            <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <!-- Pagination  -->
-                  <div class="mt-3">
-                    <ul class="pagination justify-content-center">
-                      <li class="page-item">
-                        <a href="" class="page-link">
-                          <i class="fa fa-angle-left"></i>
-                        </a>
-                      </li>
-                      <li class="page-item active">
-                        <a href="" class="page-link">1</a>
-            
-                      </li>
-                      <li class="page-item">
-                        <a href="" class="page-link">2</a>
-            
-                      </li>
-                      <li class="page-item">
-                        <a href="" class="page-link">3</a>
-                      </li>
-                      <li class="page-item">
-                        <a href="" class="page-link">4</a>
-                      </li>
-                      <li class="page-item">
-                        <a href="" class="page-link">5</a>
-                      </li>
-                      <li class="page-item">
-                        <a href="" class="page-link">
-                          <i class="fa fa-angle-right"></i>
-                        </a>
-                        </i>
-                      </li>
-                    </ul>
                   </div>
                 </div>
-                <footer>
-                    <div class="container text-white text-center py-5">
-                      <h1>Ievents</h1>
-                      <p>Copyright &copy; 2017</p>
+                <div class="search-box mt-3 d-block d-sm-none">
+                  <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                    Search with
+                  </button>
+                  <div class="dropdown-menu">
+                    <a class="dropdown-item" href="#">Location</a>
+                    <div role="separator" class="dropdown-divider"></div>
+                    <a class="dropdown-item" href="#">Name</a>
+                  </div>
+                </div>
+              </div>
+              <!-- Grid view -->
+              <div class="mt-5">
+                <div class="row">
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
                     </div>
-                  </footer>
-              </section>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-lg-4 col-md-6 col-sm-12">
+                    <div class="card">
+                      <div>
+                        <img class="card-img-top" src="img/eventCenter1.jpeg" alt="">
+                        <span class="badge text-white p-2 seat-badge ">4000 seat</span>
+                      </div>
+                      <div class="card-body d-flex flex-column">
+                        <div>
+                          <h4 class="card-title">Ottawa event center</h4>
+                          <i class="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; Ottawa, USA
+                        </div>
+                        <a href="#" role="button" class="btn bg-primary text-white mt-3">Details</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!-- Pagination  -->
+              <div class="mt-3">
+                <ul class="pagination justify-content-center">
+                  <li class="page-item">
+                    <a href="" class="page-link">
+                      <i class="fa fa-angle-left"></i>
+                    </a>
+                  </li>
+                  <li class="page-item active">
+                    <a href="" class="page-link">1</a>
+
+                  </li>
+                  <li class="page-item">
+                    <a href="" class="page-link">2</a>
+
+                  </li>
+                  <li class="page-item">
+                    <a href="" class="page-link">3</a>
+                  </li>
+                  <li class="page-item">
+                    <a href="" class="page-link">4</a>
+                  </li>
+                  <li class="page-item">
+                    <a href="" class="page-link">5</a>
+                  </li>
+                  <li class="page-item">
+                    <a href="" class="page-link">
+                      <i class="fa fa-angle-right"></i>
+                    </a>
+                    </i>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <footer>
+              <div class="container text-white text-center py-5">
+                <h1>Ievents</h1>
+                <p>Copyright &copy; 2017</p>
+              </div>
+            </footer>
+          </section>
         </div>
       </div>
     </div>
   </div>
-  
+
 
 
   <script src="js/jquery.min.js"></script>

--- a/template/centers2.html
+++ b/template/centers2.html
@@ -244,7 +244,12 @@
                     </ul>
                   </div>
                 </div>
-                
+                <footer>
+                    <div class="container text-white text-center py-5">
+                      <h1>Ievents</h1>
+                      <p>Copyright &copy; 2017</p>
+                    </div>
+                  </footer>
               </section>
         </div>
       </div>

--- a/template/css/centers2.css
+++ b/template/css/centers2.css
@@ -1,0 +1,48 @@
+body {
+  background-color: #f6f7fa;
+  overflow-x: hidden; }
+
+body > .container-fluid {
+  min-height: 700px; }
+
+#navigation-section {
+  background-color: rgba(0, 0, 0, 0.9);
+  min-height: 700px; }
+  #navigation-section .img-round {
+    height: 150px;
+    width: 150px;
+    border-radius: 50%; }
+  #navigation-section .navigation-links a {
+    color: white;
+    font-weight: bold; }
+  #navigation-section .navigation-links .list-group-item {
+    background-color: transparent;
+    border-top: 1px solid #008ed6; }
+  #navigation-section .navigation-links .list-group-item:last-child {
+    border-bottom: 1px solid #008ed6; }
+
+#centers-section {
+  min-height: 700px; }
+  #centers-section #center-section-header {
+    padding-top: 70px; }
+  #centers-section .search-box .btn {
+    color: white;
+    background-color: rgba(0, 0, 0, 0.9); }
+  #centers-section .card {
+    margin: 5px; }
+    #centers-section .card .btn {
+      background-color: rgba(0, 0, 0, 0.9) !important; }
+  #centers-section .seat-badge {
+    position: absolute;
+    top: 50%;
+    left: 60%;
+    font-size: 20px;
+    background-color: rgba(0, 0, 0, 0.4); }
+  #centers-section .pagination a {
+    font-weight: bold; }
+  #centers-section .pagination .active a {
+    background-color: black; }
+
+footer {
+  background-color: rgba(0, 0, 0, 0.9);
+  border-top: 2px solid #008ed6; }

--- a/template/scss/centers2.scss
+++ b/template/scss/centers2.scss
@@ -1,0 +1,88 @@
+$custom-black: rgba(0,0,0,0.9);
+$custom-blue: rgb(0, 142, 214);
+$background-color: #f6f7fa;
+
+
+body {
+  background-color: $background-color;
+  overflow-x: hidden; 
+}
+
+body > .container-fluid {
+    min-height: 700px;
+}
+
+#navigation-section {
+  background-color: $custom-black;
+  min-height: 700px;
+
+  .img-round {
+    height: 150px;
+    width: 150px;
+    border-radius: 50%;
+  }
+
+  .navigation-links {
+    a {
+      color: white;
+      font-weight: bold;
+    }
+  
+    .list-group-item {
+      background-color: transparent;
+      border-top: 1px solid $custom-blue;
+    }
+  
+    .list-group-item:last-child {
+      border-bottom: 1px solid $custom-blue;
+    }
+  }
+  
+}
+
+#centers-section {
+  min-height: 700px;
+
+  #center-section-header {
+    padding-top: 70px;
+  }
+
+  .search-box {
+    .btn {
+      color: white;
+      background-color: rgba(0,0,0,0.9);
+    }
+  }
+
+  .card {
+    margin: 5px;
+    .btn {
+      background-color: rgba(0,0,0,0.9) !important;
+    }
+  }
+
+  .seat-badge {
+    position: absolute;
+    top: 50%;
+    left: 60%;
+    font-size: 20px;
+    background-color: rgba(0,0,0,0.4);
+  }
+  
+  .pagination {
+    a {
+      font-weight: bold;
+    }
+    .active {
+      a {
+        background-color: rgba(0,0,0,1);
+      }
+    }
+  }
+}
+
+
+footer {
+  background-color: rgba(0,0,0,0.9);
+  border-top: 2px solid rgb(0, 142, 214);
+}


### PR DESCRIPTION
#### What does this PR do?
Add a template page for users to see all centers form the dashboard
#### Description of Task to be completed?
Create a template page for users to get all centers(TEPMLATE)
#### How should this be manually tested?
- clone the repo
- cd into the template directory
- open the centers2.html with any browser of your choice
- the template should open in that browser
#### Any background context you want to provide?
In the snapshot, disregard the duplication of the side navigation, it is due to the snapshot wanting to capture the full screen. The side navigation is a fixed and not scrollable item.
#### What are the relevant pivotal tracker stories?
#152883905
#### Screenshots (if appropriate)
![justnow5](https://user-images.githubusercontent.com/26048536/32904507-c3ceae40-caf7-11e7-8608-92c2cd91cefa.png)
#### Questions:
None