### PR TITLE
#152797337 Implement the addEvent page with react

### DIFF
--- a/client/js/actions/eventActions.js
+++ b/client/js/actions/eventActions.js
@@ -77,6 +77,10 @@ export const deleteEvent = (id, userToken) => {
   };
 }
 
+export const initializeEdit = (id) => {
+  return ({ type: 'INITIALIZE_EDIT', payload: id, });
+}
+
 // This action simply reset the status of the event store to its initial state
 export const clearStatus = () => {
   return ({ type: 'CLEAR_STATUS', });

--- a/client/js/actions/eventActions.js
+++ b/client/js/actions/eventActions.js
@@ -20,6 +20,25 @@ export const addEvent = (eventDetails, userToken) => {
   }
 };
 
+// This action contacts the server to update an event after it has beed edited
+export const updateEvent = (id, eventDetails, userToken) => {
+  return (dispatch) => {
+    dispatch({ type: 'UPDATING_EVENT' });
+    const config = {
+      headers: {
+        "access-token": userToken
+      }
+    };
+    axios.put(`${apiBaseUrl}/events/${id}`, eventDetails, config)
+      .then((response) => {
+        dispatch({ type: 'UPDATING_EVENT_RESOLVED', payload: response.data, });
+      })
+      .catch((err) => {
+        dispatch({ type: 'UPDATING_EVENT_REJECTED', payload: err.response.data, });
+      });
+  };
+}
+
 // This action contacts the server to get all of a users event
 export const getAllEvents = (userToken) => {
   return (dispatch) => {

--- a/client/js/component/common/EventCards.jsx
+++ b/client/js/component/common/EventCards.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export default (props) => {
   const eventCards = props.events.map((event => {
@@ -6,9 +7,9 @@ export default (props) => {
       <div className="card text-dark bg-white mb-3 mx-auto" style={{ maxWidth: 20 + 'rem' }} key={event.id}>
         <div className="card-header h4">
           {event.title}
-          <a href="" className="ml-4 mr-2">
-            <i className="fa fa-pencil"></i>
-          </a>
+          <Link to="/editEvent" className="ml-4 mr-2">
+            <i className="fa fa-pencil" onClick={props.edit} id={event.id}></i>
+          </Link>
           <a href="#" className="text-primary">
             <i className="fa fa-trash" onClick={props.startDelete} id={event.id}></i>
           </a>

--- a/client/js/component/container/EditEvent.jsx
+++ b/client/js/component/container/EditEvent.jsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import getAllCenters from '../../actions/centerActions';
+
+import addEventStyles from '../../../sass/addEvent.scss';
+import { UserSideNav } from '../common/SideNavigation.jsx';
+import { UserTopNav } from '../common/TopNavigation.jsx';
+import CenterOptions from '../common/CenterDropDown.jsx';
+import Header from '../common/Header.jsx';
+import { WarningAlert } from '../common/Alert';
+import { updateEvent, clearStatus } from '../../actions/eventActions';
+
+@connect((store) => {
+  return { 
+    user: store.user.user,
+    centers: store.centers.centers,
+    toEdit: store.events.toEdit,
+    status: {
+      error: store.events.status.updatingError.message,
+      success: store.events.status.updated,
+    }
+  }
+})
+
+export default class EditEvent extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      title: null,
+      description: null,
+      date: null,
+      centerId: null,
+    };
+  }
+
+  componentDidMount() {
+    this.props.dispatch(getAllCenters());
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(clearStatus());
+  }
+
+
+  // This method uses user input to update the state
+  getInput = (e) => {
+    const state = this.state;
+    state[e.target.name] = e.target.value;
+    this.setState(state);
+  }
+
+  // This method fires the action to create an event
+  update = () => {
+    const {
+     title,
+      description,
+      centerId
+    } = this.state;
+    let date = this.state.date ? this.state.date.replace(/-/g, '/') : null;
+    const eventDetails = { title, description, date, centerId };
+    const eventId = this.props.toEdit.id;
+    this.props.dispatch(updateEvent(eventId, eventDetails, this.props.user.token));
+  }
+
+  render() {
+
+    if (this.props.status.success) {
+      return (<Redirect to="/events" />);
+    } else {
+      return (
+        <div>
+          {/* Top navigation on small screen */}
+          <UserTopNav name={this.props.user.name} title='Add Event' />
+
+          <div class="container-fluid">
+            <div class="row">
+
+              {/*  Side navigation on large screen */}
+              <UserSideNav userName={this.props.user.name} />
+
+              {/* Main content */}
+              <div class="col-lg-10 offset-md-2" id="add-event-section">
+
+                {/* Content Header(navigation) on large screen */}
+                <Header text='Add Event' />
+
+                {/* Input form */}
+                <form class="mt-lg-5 w-lg-50">
+                  <WarningAlert message={this.props.status.error} />
+                  <div class="form-group">
+                    <label for="title">Title</label>
+                    <input type="text" class="form-control"
+                      id="title" defaultValue={this.props.toEdit.title}
+                      placeholder="A short description of your event"
+                      name="title" onChange={this.getInput} />
+                    <small id="emailHelp"
+                      class="form-text text-muted">Less than 30 characters</small>
+                  </div>
+                  <div class="form-group">
+                    <label for="description">Description</label>
+                    <textarea class="form-control" id="description"
+                      rows="6" defaultValue={this.props.toEdit.description}
+                      placeholder="More details about the event"
+                      name="description" onChange={this.getInput}></textarea>
+                    <small id="emailHelp"
+                      class="form-text text-muted">Less than 200 characters</small>
+                  </div>
+                </form>
+                <form class="my-3 form-inline">
+                  <div class="form-group">
+                    <label for="date">Date</label>
+                    <input type="date" id="date"
+                      class="form-control mx-sm-3"
+                      defaultValue={this.props.toEdit.date.replace(/\//g, '-')}
+                      name="date" onChange={this.getInput} />
+                  </div>
+                  <div class="form-group">
+                    <label for="centers">Choose a Center</label>
+                    <select id="centers" class="form-control ml-md-3"
+                      onChange={this.getInput}>
+                      <option>choose a center</option>
+                      <CenterOptions centers={this.props.centers} />
+                    </select>
+                  </div>
+                </form>
+
+                <a class="btn btn-outline-dark" onClick={this.update}>Update</a>
+              </div>
+            </div>
+          </div>
+
+          <footer class="d-block d-sm-none mt-5">
+            <div class="container text-white text-center py-5">
+              <h1>Ievents</h1>
+              <p>Copyright &copy; 2017</p>
+            </div>
+          </footer>
+        </div>
+      );
+    }
+  }
+}

--- a/client/js/component/container/EditEvent.jsx
+++ b/client/js/component/container/EditEvent.jsx
@@ -71,7 +71,7 @@ export default class EditEvent extends React.Component {
       return (
         <div>
           {/* Top navigation on small screen */}
-          <UserTopNav name={this.props.user.name} title='Add Event' />
+          <UserTopNav name={this.props.user.name} title='Edit Event' />
 
           <div class="container-fluid">
             <div class="row">
@@ -83,7 +83,7 @@ export default class EditEvent extends React.Component {
               <div class="col-lg-10 offset-md-2" id="add-event-section">
 
                 {/* Content Header(navigation) on large screen */}
-                <Header text='Add Event' />
+                <Header text='Edit Event' />
 
                 {/* Input form */}
                 <form class="mt-lg-5 w-lg-50">

--- a/client/js/component/container/Events.jsx
+++ b/client/js/component/container/Events.jsx
@@ -8,7 +8,7 @@ import { ConfirmModal } from '../common/Modal';
 import Header from '../common/Header.jsx';
 import EventCards from '../common/EventCards.jsx';
 
-import { getAllEvents, deleteEvent } from '../../actions/eventActions';
+import { getAllEvents, deleteEvent, initializeEdit } from '../../actions/eventActions';
 
 @connect((store) => {
   return {
@@ -68,6 +68,11 @@ export default class Events extends React.Component {
     this.props.dispatch(deleteEvent(e.target.id, this.props.user.token));
   }
 
+  // This method initialize editing of an event
+  onEdit = (e) => {
+    this.props.dispatch(initializeEdit(e.target.id))
+  }
+
   render() {
     return (
       <div>
@@ -87,14 +92,18 @@ export default class Events extends React.Component {
               {/* Event Grid */}
               <div className="mt-5">
                 <div className="card-columns mx-auto">
-                  <EventCards events={this.props.events} startDelete={this.startDelete} remove={this.removeEvent}/>
+                  <EventCards events={this.props.events}
+                    startDelete={this.startDelete}
+                    remove={this.removeEvent}
+                    edit={this.onEdit} />
+
                 </div>
               </div>
 
               <ConfirmModal visible={this.state.modalVisible}
                 onCancel={this.cancelDelete}
-                onOK={this.finishDelete} 
-                children="Are you sure you want to delete this event?"/>
+                onOK={this.finishDelete}
+                children="Are you sure you want to delete this event?" />
 
             </div>
           </div>

--- a/client/js/index.jsx
+++ b/client/js/index.jsx
@@ -8,6 +8,7 @@ import Signup from './component/container/Signup.jsx';
 import Signin from './component/container/Signin.jsx';
 import AddEvent from './component/container/AddEvent.jsx';
 import Events from './component/container/Events.jsx';
+import EditEvent from './component/container/EditEvent.jsx';
 import userPage from './component/container/UserPage.jsx';
 
 const history = createBrowserHistory();
@@ -17,6 +18,7 @@ const App = () => {
             <Route exact path='/' component={Signup} />
             <Route exact path='/users/login' component={Signin} />
             <Route exact path='/addEvent' component={AddEvent} />
+            <Route exact path='/editEvent' component={EditEvent} />            
             <Route exact path='/events' component={Events} />
         </Switch>
     )

--- a/client/js/reducers/eventReducer.js
+++ b/client/js/reducers/eventReducer.js
@@ -1,12 +1,18 @@
+import _ from 'lodash';
+
 let initialState = {
   events: [],
+  toEdit: null,
   status: {
     fetching: false,
     fetched: false,
     fetchingError: false,
-    adding: false, 
+    adding: false,
     added: false,
     addingError: false,
+    updating: false,
+    updated: false,
+    updatingError: false,
     deleting: false,
     daleted: false,
     deletingError: false,
@@ -84,6 +90,52 @@ export default (state = initialState, action) => {
         },
       };
     }
+    case 'INITIALIZE_EDIT': {
+      const event = _.find(state.events, { id: Number(action.payload) });
+      return {
+        ...state,
+        toEdit: event,
+      }
+    }
+    case 'UPDATING_EVENT': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          updating: true,
+          updated: false,
+          updatingError: false,
+        },
+      }
+    }
+    case 'UPDATING_EVENT_RESOLVED': {
+      const id = action.payload.event.id;
+      const index = _.findIndex(state.events, { id });
+      const newEvents = [...state.events];
+      newEvents[index] = action.payload.event;
+      return {
+        ...state,
+        events: newEvents,
+        status: {
+          ...state.status,
+          updating: false,
+          updated: true,
+          updatingError: false,
+        },
+
+      }
+    }
+    case 'UPDATING_EVENT_REJECTED': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          updating: false,
+          updated: false,
+          updatingError: action.payload,
+        },
+      }
+    }
     case 'DELETING_EVENT': {
       return {
         ...state,
@@ -103,7 +155,7 @@ export default (state = initialState, action) => {
           deleting: false,
           deleted: true,
           deletingError: false,
-        } 
+        }
       }
     }
     case 'DELETING_EVENT_REJECTED': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5033,6 +5033,12 @@
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+          "dev": true
+        },
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
@@ -6460,10 +6466,9 @@
       }
     },
     "lodash": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-      "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-      "dev": true
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash-es": {
       "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "history": "^4.7.2",
     "jquery": "^3.2.1",
     "jsonwebtoken": "^8.1.0",
+    "lodash": "^4.17.4",
     "morgan": "^1.9.0",
     "node-sass": "^4.7.2",
     "pg": "^7.4.0",


### PR DESCRIPTION
#### What does this PR do?
It uses react and redux to implement the edit-events page consuming the API endpoint for editing events
#### Description of Task to be completed?
User should be able to modify an event he/she added
#### How should this be manually tested?
- clone the repo
- cd into the project directory
- Run `npm install` to install all the dependency
- Run `npm run react:dev`
- visit the port where the webpack-dev-server started, the signup page should be loaded there
- Fill the form and click register,
- Add some sample events from the add-event page
- Navigate to the events page, and click on the edit icon for an event
- After editing, click update
- The events should be updated on the user events page
#### Any background context you want to provide?
- The frontend still uses the locally hosted server, so you would have to create a .env file to fulfill all the needed environment variables, the run `npm run server:dev`
#### What are the relevant pivotal tracker stories?
#152797337
#### Screenshots (if appropriate)
![screencapture-localhost-8080-editevent-1512239178881](https://user-images.githubusercontent.com/26048536/33518534-ccc4f224-d796-11e7-978e-c4fed8b1bf97.png)
#### Questions:
None