### PR TITLE
#152797404 Implement the center details view with react

### DIFF
--- a/client/js/actions/centerActions.js
+++ b/client/js/actions/centerActions.js
@@ -15,4 +15,11 @@ const getAllCenters = () => {
   }
 }
 
+export const showCenterModal = (centerId) => {
+  return {
+    type: 'SHOW_CENTER_MODAL',
+    payload: centerId,
+  }
+}
+
 export default getAllCenters;

--- a/client/js/component/common/CenterCards.jsx
+++ b/client/js/component/common/CenterCards.jsx
@@ -4,22 +4,27 @@ const defaultImage = '../../../images/defaultImgx4.jpeg';
 
 export default (props) => {
   return props.centers.map((center) => (
-      <div className="col-lg-4 col-md-6 col-sm-12" key={center.id}>
-        <div className="card">
+    <div className="col-lg-4 col-md-6 col-sm-12" key={center.id}>
+      <div className="card">
+        <div>
+          <img className="card-img-top" src={center.images ? center.images[0] : defaultImage} alt="" />
+          <span className="badge text-white p-2 seat-badge ">{center.capacity} seats</span>
+        </div>
+        <div className="card-body d-flex flex-column">
           <div>
-            <img className="card-img-top" src={center.images ? center.images[0] : defaultImage} alt="" />
-            <span className="badge text-white p-2 seat-badge ">{center.capacity} seats</span>
+            <h4 className="card-title text-capitalize">{center.name}</h4>
+            <i className="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; <span className="text-capitalize">{center.location}</span>
           </div>
-          <div className="card-body d-flex flex-column">
-            <div>
-              <h4 className="card-title text-capitalize">{center.name}</h4>
-              <i className="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; <span className="text-capitalize">{center.location}</span>
-            </div>
-            <a role="button" class="btn text-white mt-3" data-toggle="modal" data-target="#center-details-modal">Details</a>
-          </div>
+          <a role="button"
+            class="btn text-white mt-3"
+            data-toggle="modal"
+            data-target="#center-details-modal"
+            id={center.id}
+            onClick={props.btnAction}>Details</a>
         </div>
       </div>
-    )); 
+    </div>
+  ));
 }
 
 

--- a/client/js/component/common/Modal/CenterModal.jsx
+++ b/client/js/component/common/Modal/CenterModal.jsx
@@ -37,8 +37,8 @@ const BookingTable = (props) => {
 
 };
 
-const checkForBooking = (condition) => {
-  if (condition) {
+const checkForBooking = (dates) => {
+  if (dates && dates.length !== 0) {
     return {
       element: (<a href=".multi-collapse"
         className="font-italic small"

--- a/client/js/component/common/Modal/CenterModal.jsx
+++ b/client/js/component/common/Modal/CenterModal.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import MonthToString from '../../../helpers/Date';
+
+const defaultImage = '../../../../images/defaultImgx4.jpeg';
+
+const BookingTable = (props) => {
+  if (!props.display) {
+    return null;
+  } else {
+    return (
+      <table className="table table-striped">
+        <thead>
+          <tr>
+            <th scope="col">Year</th>
+            <th scope="col">Month</th>
+            <th scope="col">Day</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            props.tableContent.bookedOn.map((date, index) => {
+              const dateData = date.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
+              return (
+                <tr key={index}>
+                  <td scope="row">{dateData[1]}</td>
+                  <td>{MonthToString(Number(dateData[2])).monthName}</td>
+                  <td>{dateData[3]}</td>
+                </tr>
+              );
+            })
+          }
+        </tbody>
+      </table>
+    )
+  }
+
+};
+
+const checkForBooking = (condition) => {
+  if (condition) {
+    return {
+      element: (<a href=".multi-collapse"
+        className="font-italic small"
+        data-toggle="collapse">
+        This center has been booked on...</a>
+      ),
+      displayTable: true,
+    }
+  } else {
+    return {
+      element: (<p className="text-muted small mb-0">
+        This center has not being booked at all, why don't you be the first.</p>),
+      displayTable: false,
+    }
+  }
+};
+
+const CenterModal = (props) => (
+  <div className="modal fade" id="center-details-modal" tabIndex="-1" role="dialog" data-backdrop="static" data-keyboard="false">
+    <div className="modal-dialog" role="document">
+      <div className="modal-content">
+        <div className=" collapse show multi-collapse">
+          <div className="card">
+            <img className="card-img-top"
+              src={props.modalContent.images ? props.modalContent.images[0] : defaultImage} alt="The center image" />
+            <span className="badge text-white p-2 seat-badge">{props.modalContent.capacity} seat</span>
+            <div className="card-body d-flex flex-column">
+              <div>
+                <h4 className="card-title d-inline">{props.modalContent.name}</h4>
+                <a href="" className="close text-primary" data-dismiss="modal" aria-label="Close">
+                  <i className="fa fa-remove fa-fw"></i>
+                </a>
+                <br />
+                <i className="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; <span>{props.modalContent.location}</span>
+              </div>
+              <p>{props.modalContent.details}</p>
+              {checkForBooking(props.modalContent.bookedOn).element}
+              <Link to="/users/login" className="btn text-white mt-2 btn-block" data-dismiss="modal">
+                  Book now for ₦{props.modalContent.price}/Day
+              </Link>
+            </div>
+          </div>
+        </div>
+        {/* Booking dates */}
+        <div className="collapse multi-collapse ">
+          <div className="card">
+            <div className="card-header clear-fix bg-white">
+              <a href=".multi-collapse" className="float-right" data-toggle="collapse">
+                <i className="fa fa-remove"></i>
+              </a>
+              <h4 className="card-title">{props.modalContent.name}</h4>
+              <i className="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; <span className="text-capitalize">{props.modalContent.location}</span>
+              <p className="text-muted small mb-0">This center has already been booked on the following dates</p>
+            </div>
+            <BookingTable tableContent={props.modalContent} display={checkForBooking(props.modalContent.bookedOn).displayTable} />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+
+export default CenterModal;

--- a/client/js/component/common/Modal/index.js
+++ b/client/js/component/common/Modal/index.js
@@ -1,5 +1,6 @@
 import ConfirmModal from './ConfirmModal.jsx';
+import CenterModal from './CenterModal.jsx';
 import Modal from './Modal.jsx';
 
-export { ConfirmModal };
+export { ConfirmModal, CenterModal };
 export default Modal;

--- a/client/js/component/container/Centers1.jsx
+++ b/client/js/component/container/Centers1.jsx
@@ -7,7 +7,7 @@ import centersStyles from '../../../sass/centers.scss';
 import TopNavigation from '../common/TopNavigation.jsx';
 import Footer from '../common/Footer.jsx';
 import CenterCards from '../common/CenterCards.jsx';
-import CenterModal from '../common/Modal/CenterModal.jsx';
+import { CenterModal } from '../common/Modal';
 
 @connect((store) => {
   return {

--- a/client/js/component/container/Centers1.jsx
+++ b/client/js/component/container/Centers1.jsx
@@ -1,21 +1,36 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import getAllCenters from '../../actions/centerActions';
+import { showCenterModal } from '../../actions/centerActions';
 
 import centersStyles from '../../../sass/centers.scss';
 import TopNavigation from '../common/TopNavigation.jsx';
 import Footer from '../common/Footer.jsx';
 import CenterCards from '../common/CenterCards.jsx';
+import CenterModal from '../common/Modal/CenterModal.jsx';
 
 @connect((store) => {
   return {
     centers: store.centers.centers,
+    modalContent: store.centers.modalContent ? store.centers.modalContent : {
+      name: null,
+      images: [],
+      details: null,
+      capacity: null,
+      price: null,
+      bookedOn: [],
+      type: null,
+    },
   }
 })
 
 export default class Centers1 extends React.Component {
   componentWillMount() {
     this.props.dispatch(getAllCenters());
+  }
+
+  showModal = (e) => {
+    this.props.dispatch(showCenterModal(e.target.id));
   }
 
   render() {
@@ -56,11 +71,14 @@ export default class Centers1 extends React.Component {
             {/* Centers Grid */}
             <div className="mt-5">
               <div className="row">
-                <CenterCards centers={this.props.centers} />
+                <CenterCards centers={this.props.centers} btnAction={this.showModal} />
               </div>
             </div>
           </div>
         </section>
+
+        {/* Modal */}
+        <CenterModal modalContent={this.props.modalContent} />
 
         <Footer />
 

--- a/client/js/component/container/Centers2.jsx
+++ b/client/js/component/container/Centers2.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Rediret } from 'react-router-dom';
 import getAllCenters from '../../actions/centerActions';
+import { showCenterModal } from '../../actions/centerActions';
 
 import styles from '../../../sass/centers2.scss';
-import CenterCards from '../common/CenterCards.jsx';
 import { UserTopNav } from '../common/TopNavigation.jsx';
 import { UserSideNav } from '../common/SideNavigation.jsx';
 import Header from '../common/Header.jsx';
+import CenterCards from '../common/CenterCards.jsx';
+import { CenterModal } from '../common/Modal';
 
 
 @connect((store) => {
@@ -15,12 +17,25 @@ import Header from '../common/Header.jsx';
     authenticated: store.user.status.fetched,
     user: store.user.user,
     centers: store.centers.centers,
+    modalContent: store.centers.modalContent ? store.centers.modalContent : {
+      name: null,
+      images: [],
+      details: null,
+      capacity: null,
+      price: null,
+      bookedOn: [],
+      type: null,
+    },
   }
 })
 
 export default class Centers2 extends React.Component {
   componentWillMount() {
     this.props.dispatch(getAllCenters());
+  }
+
+  showModal = (e) => {
+    this.props.dispatch(showCenterModal(e.target.id));
   }
 
   render() {
@@ -75,11 +90,14 @@ export default class Centers2 extends React.Component {
                     {/* Centers  Grid*/}
                     <div className="mt-5">
                       <div className="row">
-                        <CenterCards centers={this.props.centers} />
+                        <CenterCards centers={this.props.centers} btnAction={this.showModal}/>
                       </div>
                     </div>
                   </div>
                 </section>
+
+                {/* Modal */}
+                <CenterModal modalContent={this.props.modalContent} />
 
                 {/* Footer on large screen */}
                 <footer class="d-none d-lg-block mt-5">

--- a/client/js/helpers/Date.js
+++ b/client/js/helpers/Date.js
@@ -1,0 +1,42 @@
+const MonthToString = (monthNumber) => {
+  switch(monthNumber){
+    case 1: {
+      return { monthNo: 1, monthName: 'January' };
+    }
+    case 2: {
+      return { monthNo: 2, monthName: 'February' };
+    }
+    case 3: {
+      return { monthNo: 3, monthName: 'March' };
+    }
+    case 4: {
+      return { monthNo: 4, monthName: 'April' };
+    }
+    case 5: {
+      return { monthNo: 5, monthName: 'May' };
+    }
+    case 6: {
+      return { monthNo: 6, monthName: 'June' };
+    }
+    case 7: {
+      return { monthNo: 7, monthName: 'July' };
+    }
+    case 8: {
+      return { monthNo: 8 , monthName: 'August' };
+    }
+    case 9: {
+      return { monthNo: 9, monthName: 'September' };
+    }
+    case 10: {
+      return { monthNo: 10, monthName: 'October' };
+    }
+    case 11: {
+      return { monthNo: 11, monthName: 'November' };
+    }
+    case 12: {
+      return { monthNo: 12, monthName: 'December' };
+    }
+  }
+}
+
+export default MonthToString;

--- a/client/js/reducers/centerReducers.js
+++ b/client/js/reducers/centerReducers.js
@@ -1,5 +1,8 @@
+import _ from 'lodash';
+
 let initialState = {
   centers: [],
+  modalContent: null,
   status: {
     fetching: false,
     fetched: false,
@@ -44,8 +47,15 @@ export default (state = initialState, action) => {
         },
       };
     }
+    case 'SHOW_CENTER_MODAL': {
+      const modalContent = _.find(state.centers, {id: Number(action.payload)});
+      return {
+        ...state,
+        modalContent: modalContent,
+      }
+    }
     default: {
-      return state;
+      return state; 
     }
   }
 }

--- a/client/sass/centers.scss
+++ b/client/sass/centers.scss
@@ -74,6 +74,9 @@ body > nav {
       }
     }
   }
+  .card-img-top {
+    height: 250px;
+  }
 
   .seat-badge {
     position: absolute;

--- a/client/sass/centers.scss
+++ b/client/sass/centers.scss
@@ -21,7 +21,6 @@ body > nav {
   }
 
   .card {
-    margin: 5px;
 
     .card-img-top {
       height: 250px;
@@ -67,7 +66,7 @@ body > nav {
       width: 400px;
       .seat-badge {
         position: absolute;
-        top: 35%;
+        top: 45%;
         left: 65%;
         font-size: 20px;
         background-color: rgba(0,0,0,0.4);
@@ -80,7 +79,7 @@ body > nav {
 
   .seat-badge {
     position: absolute;
-    top: 30%;
+    top: 40%;
     left: 60%;
     font-size: 20px;
     background-color: rgba(0,0,0,0.4);

--- a/client/sass/centers2.scss
+++ b/client/sass/centers2.scss
@@ -52,7 +52,6 @@ body > nav {
   }
 
   .card {
-    margin: 5px;
     .btn {
       background-color: $custom-black !important;
     }
@@ -93,7 +92,7 @@ body > nav {
       width: 400px;
       .seat-badge {
         position: absolute;
-        top: 35%;
+        top: 45%;
         left: 65%;
         font-size: 20px;
         background-color: rgba(0,0,0,0.4);
@@ -103,7 +102,7 @@ body > nav {
 
   .seat-badge {
     position: absolute;
-    top: 30%;
+    top: 40%;
     left: 60%;
     font-size: 20px;
     background-color: rgba(0,0,0,0.4);


### PR DESCRIPTION
#### What does this PR do?
It uses react and redux to implement the view that shows the details of a center
#### Description of Task to be completed?
User should be able to see the details of a center
#### How should this be manually tested?
- clone the repo
- cd into the project directory
- Run `npm install` to install all the dependency
- Run `npm run react:dev`
- visit the port where the webpack-dev-server started
- try posting some centers through the API endpoint
- navigate to the centers page, all the centers should be laid out in cards
- Click on the details button on one of the centers, the full details of that center should show in a modal
#### Any background context you want to provide?
- The frontend still uses the locally hosted server, so you would have to create a .env file to fulfill all the needed environment variables, the run `npm run server:dev`
#### What are the relevant pivotal tracker stories?
#152797404 
#### Screenshots (if appropriate)
![screencapture-localhost-8080-centers2-1512762068040](https://user-images.githubusercontent.com/26048536/33782238-2aca7e32-dc58-11e7-8273-48adbff16ec1.png)
#### Questions:
None