### PR TITLE
#152797380 Implement the add center page with react

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+engines:
+  duplication:
+    enabled: true
+    checks:
+      Similar code:
+        enabled: false
+    config:
+      languages:
+      - javascript
+  fixme:
+    enabled: true
+  eslint:
+    enabled: true
+ratings:
+  paths:
+  - "server/*.js"
+  - "server/**/*.js"
+exclude_paths:
+- client/
+- server/src/models/
+- server/test/
+- template/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,5 +18,6 @@ ratings:
 exclude_paths:
 - client/
 - server/src/models/
+- test/
 - server/test/
 - template/

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,3 @@
-"service_name": "travis_ci"
-"service_job_id": "305240897"
-repo_token: e7mSRtWKyUTGvG3p5VpbVdkBfvRRiH4er
+service_name: "travis_ci"
+service_job_id: "305240897"
  

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,3 @@
-service_name: "travis_ci"
+service_name: "travis-ci"
 service_job_id: "305240897"
  

--- a/client/js/actions/centerActions.js
+++ b/client/js/actions/centerActions.js
@@ -15,11 +15,34 @@ const getAllCenters = () => {
   }
 }
 
+export const addCenter = (centerDetails, userToken) => {
+  return (dispatch) => {
+    dispatch({ type: 'ADDDING_CENTER' });
+    const config = {
+      headers: {
+        "access-token": userToken,
+      }
+    }
+    axios.post(`${apiBaseUrl}/centers`, centerDetails, config)
+      .then((response) => {
+        dispatch({ type: 'ADDING_CENTER_RESOLVED', payload: response.data, })
+      })
+      .catch((err) => {
+        dispatch({ type: 'ADDING_CENTER_REJECTED', payload: err.response.data, });
+      })
+  }
+}
+
 export const showCenterModal = (centerId) => {
   return {
     type: 'SHOW_CENTER_MODAL',
     payload: centerId,
   }
+}
+
+// This action simply reset the status of the center store to its initial state
+export const clearStatus = () => {
+  return ({ type: 'CLEAR_STATUS', });
 }
 
 export default getAllCenters;

--- a/client/js/component/common/CenterCards.jsx
+++ b/client/js/component/common/CenterCards.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const defaultImage = '../../../images/defaultImgx4.jpeg';
 
-export default (props) => {
+const CenterCards = (props) => {
   return props.centers.map((center) => (
     <div className="col-lg-4 col-md-6 col-sm-12" key={center.id}>
       <div className="card">
@@ -15,16 +15,34 @@ export default (props) => {
             <h4 className="card-title text-capitalize">{center.name}</h4>
             <i className="fa fa-map-marker fa-fw" aria-hidden="true"></i>&nbsp; <span className="text-capitalize">{center.location}</span>
           </div>
-          <a role="button"
-            class="btn text-white mt-3"
-            data-toggle="modal"
-            data-target="#center-details-modal"
+          <ActionBtn isAdmin={props.isAdmin || false}
             id={center.id}
-            onClick={props.btnAction}>Details</a>
+            editActions={props.editAction}
+            btnAction={props.btnAction} />
         </div>
       </div>
     </div>
   ));
 }
 
+const ActionBtn = (props) => {
+  if (props.isAdmin) {
+    return (
+      <a role="button"
+        class="btn text-white mt-3"
+        id={props.id}
+        onClick={props.editAction}>Edit</a>
+    );
+  } else {
+    return (
+      <a role="button"
+        class="btn text-white mt-3"
+        data-toggle="modal"
+        data-target="#center-details-modal"
+        id={props.id}
+        onClick={props.btnAction}>Details</a>
+    );
+  }
+}
 
+export default CenterCards;

--- a/client/js/component/common/SideNavigation.jsx
+++ b/client/js/component/common/SideNavigation.jsx
@@ -6,12 +6,12 @@ import { clearUser } from '../../actions/authAction';
 
 @connect((store) => {
   return {
-
+    isAdmin: (store.user.user.role === 'admin') ? true : false,
   }
 })
 
 // This is the side navigation that appears when a user is logged in(Large Screen)
-class UserSideNav extends React.Component {
+export default class UserSideNav extends React.Component {
   logout = () => {
     this.props.dispatch(clearUser());
   }
@@ -32,6 +32,7 @@ class UserSideNav extends React.Component {
             <Link to="/centers2" class="list-group-item">
               <i class="fa fa-bank fa-fw" aria-hidden="true"></i>&nbsp; Centers
             </Link>
+            <AdminOptions isAdmin={this.props.isAdmin} />
             <Link to="/" class="list-group-item" onClick={this.logout}>
               <i class="fa fa-power-off fa-fw" aria-hidden="true"></i>&nbsp; Logout
             </Link>
@@ -42,31 +43,21 @@ class UserSideNav extends React.Component {
   }
 }
 
-// This is the side navigation that appears when an admin is logged in(Large Screen)
-const AdminSideNav = (props) => {
-  return (
-    <div class="col-lg-2 fixed-top  d-none d-lg-block" id="navigation-section">
-      <div class="profile-pic mt-5 text-center">
-        <p class="lead text-white pt-3" id="userName">Admin</p>
+// The extra option that is displayed when an admin is logged in
+const AdminOptions = (props) => {
+  if (props.isAdmin) {
+    return (
+      <div>
+        <Link to="#" class="list-group-item">
+          <i class="fa fa-plus fa-fw" aria-hidden="true"></i>&nbsp; Add Center
+        </Link>
+        <Link to="#" class="list-group-item">
+          <i class="fa fa-tasks fa-fw" aria-hidden="true"></i>&nbsp; Transactions
+        </Link>
       </div>
-      <div class="pt-3 navigation-links">
-        <div class="list-group">
-          <Link to="/centers2" class="list-group-item">
-            <i class="fa fa-bank fa-fw" aria-hidden="true"></i>&nbsp; Centers
-        </Link>
-          <Link to="#" class="list-group-item">
-            <i class="fa fa-plus fa-fw" aria-hidden="true"></i>&nbsp; Add Center
-        </Link>
-          <Link to="#" class="list-group-item">
-            <i class="fa fa-tasks fa-fw" aria-hidden="true"></i>&nbsp; Transactions
-        </Link>
-          <Link to="#" class="list-group-item">
-            <i class="fa fa-power-off fa-fw" aria-hidden="true"></i>&nbsp; Logout
-        </Link>
-        </div>
-      </div>
-    </div>
-  );
-};
+    );
+  } else {
+    return null;
+  }
+}
 
-export { UserSideNav, AdminSideNav };

--- a/client/js/component/common/SideNavigation.jsx
+++ b/client/js/component/common/SideNavigation.jsx
@@ -48,7 +48,7 @@ const AdminOptions = (props) => {
   if (props.isAdmin) {
     return (
       <div>
-        <Link to="#" class="list-group-item">
+        <Link to="/addCenter" class="list-group-item">
           <i class="fa fa-plus fa-fw" aria-hidden="true"></i>&nbsp; Add Center
         </Link>
         <Link to="#" class="list-group-item">

--- a/client/js/component/common/TopNavigation.jsx
+++ b/client/js/component/common/TopNavigation.jsx
@@ -88,9 +88,9 @@ export class UserTopNav extends React.Component {
 const AdminOptions = (props) => {
   if (props.isAdmin) {
     return (
-      <span class="d-flex flex-row">
+      <span class="d-flex flex-column flex-md-row">
         <li class="nav-item">
-          <Link to="#" class="nav-link">Add Center</Link>
+          <Link to="/addCenter" class="nav-link">Add Center</Link>
         </li>
         <li class="nav-item">
           <Link to="#" class="nav-link">Transactions</Link>

--- a/client/js/component/common/TopNavigation.jsx
+++ b/client/js/component/common/TopNavigation.jsx
@@ -4,53 +4,6 @@ import { connect } from 'react-redux';
 
 import { clearUser } from '../../actions/authAction';
 
-@connect((store) => {
-  return {
-
-  }
-})
-
-// The navigation that is specific to user page
-class UserTopNav extends React.Component {
-  logout = () => {
-    this.props.dispatch(clearUser());
-  }
-  render() {
-    return (
-      <div>
-        <nav class="navbar navbar-expand-sm navbar-dark fixed-top d-block d-lg-none">
-          <div class="container">
-            <a href="" class="navbar-brand">
-              <strong class="text-capitalize">{this.props.name}</strong>
-              <br />
-              <p class="h6">{this.props.title}</p>
-            </a>
-            <button class="navbar-toggler" data-toggle="collapse" data-target="#navMenu">
-              <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navMenu">
-              <ul class="navbar-nav ml-auto">
-                <li class="nav-item">
-                  <Link to="/events" className="nav-link">My events</Link>
-                </li>
-                <li class="nav-item">
-                  <Link to="/addEvent" className="nav-link">Add Events</Link>
-                </li>
-                <li class="nav-item">
-                  <Link to="/centers2" className="nav-link">Centers</Link>
-                </li>
-                <li class="nav-item">
-                  <Link to="/" className="nav-link" onClick={this.logout}>Logout</Link>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </nav>
-      </div>
-    );
-  }
-}
-
 // The navigation that is returned by default
 export default () => {
   return (
@@ -83,40 +36,68 @@ export default () => {
   );
 }
 
-// The navigation that is specific to admin page  
-const AdminTopNav = (props) => {
-  return (
-    <div>
-      <nav class="navbar navbar-expand-sm navbar-dark fixed-top d-block d-lg-none">
-        <div class="container">
-          <a href="" class="navbar-brand">
-            <strong>Admin</strong>
-            <br />
-            <p class="h6">{props.title}</p>
-          </a>
-          <button class="navbar-toggler" data-toggle="collapse" data-target="#navMenu">
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div class="collapse navbar-collapse" id="navMenu">
-            <ul class="navbar-nav ml-auto">
-              <li class="nav-item">
-                <Link to="/centers2" class="nav-link">Centers</Link>
-              </li>
-              <li class="nav-item">
-                <Link to="#" class="nav-link">Add Center</Link>
-              </li>
-              <li class="nav-item">
-                <Link to="#" class="nav-link">Transactions</Link>
-              </li>
-              <li class="nav-item">
-                <Link to="#" class="nav-link">Logout</Link>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-    </div>
-  );
-};
+@connect((store) => {
+  return {
+    isAdmin: (store.user.user.role === 'admin') ? true : false,
+  }
+})
 
-export { UserTopNav, AdminTopNav };
+// The navigation that is specific to user page
+export class UserTopNav extends React.Component {
+  logout = () => {
+    this.props.dispatch(clearUser());
+  }
+  render() {
+    return (
+      <div>
+        <nav class="navbar navbar-expand-sm navbar-dark fixed-top d-block d-lg-none">
+          <div class="container">
+            <a href="" class="navbar-brand">
+              <strong class="text-capitalize">{this.props.name}</strong>
+              <br />
+              <p class="h6">{this.props.title}</p>
+            </a>
+            <button class="navbar-toggler" data-toggle="collapse" data-target="#navMenu">
+              <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navMenu">
+              <ul class="navbar-nav ml-auto">
+                <li class="nav-item">
+                  <Link to="/events" className="nav-link">My events</Link>
+                </li>
+                <li class="nav-item">
+                  <Link to="/addEvent" className="nav-link">Add Events</Link>
+                </li>
+                <li class="nav-item">
+                  <Link to="/centers2" className="nav-link">Centers</Link>
+                </li>
+                <AdminOptions isAdmin={this.props.isAdmin}/>
+                <li class="nav-item">
+                  <Link to="/" className="nav-link" onClick={this.logout}>Logout</Link>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </nav>
+      </div>
+    );
+  }
+}
+
+// The extra options that is displayed when an admin is logged in
+const AdminOptions = (props) => {
+  if (props.isAdmin) {
+    return (
+      <span class="d-flex flex-row">
+        <li class="nav-item">
+          <Link to="#" class="nav-link">Add Center</Link>
+        </li>
+        <li class="nav-item">
+          <Link to="#" class="nav-link">Transactions</Link>
+        </li>
+      </span>
+    );
+  } else {
+    return null;
+  }
+}

--- a/client/js/component/container/AddCenter.jsx
+++ b/client/js/component/container/AddCenter.jsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+import { addCenter, clearStatus } from '../../actions/centerActions';
+
+import UserSideNav from '../common/SideNavigation.jsx';
+import Header from '../common/Header.jsx';
+import { UserTopNav } from '../common/TopNavigation.jsx';
+import { WarningAlert } from '../common/Alert';
+
+@connect((store) => {
+  return {
+    user: store.user.user,
+    authenticated: store.user.status.fetched,
+    status: {
+      error: store.centers.status.addingError.message,
+      success: store.centers.status.added,
+    }
+  }
+})
+
+export default class AddCenter extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      name: null,
+      location: null,
+      details: null,
+      capacity: null,
+      price: null,
+      type: null,
+      image: null,
+    }
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(clearStatus());
+  }
+
+  // This method uses user input to update the state
+  getInput = (e) => {
+    const state = this.state;
+    state[e.target.name] = e.target.value;
+    this.setState(state);
+  }
+
+  // This method fires the action to create an event
+  add = () => {
+    const {
+      name,
+      location,
+      details,
+      capacity,
+      price,
+      type,
+      image,
+    } = this.state;
+    const centerDetails = { name, location, details, capacity, price, type, image };
+    this.props.dispatch(addCenter(centerDetails, this.props.user.token));
+  }
+
+  render() {
+    if (!this.props.authenticated) {
+      return (<Redirect to="/users/login" />)
+    } else if (this.props.status.success) {
+      return (<Redirect to="/centers2" />);
+    } else {
+      return (
+        <div>
+          {/* Top navigation on small screen */}
+          <UserTopNav name={this.props.user.name} title='Add Event' />
+
+          <div className="container-fluid">
+            <div className="row">
+
+              {/*  Side navigation on large screen */}
+              <UserSideNav userName={this.props.user.name} />
+
+              {/* Main content */}
+              <div class="col-lg-10 offset-md-2" id="add-event-section">
+
+                {/* Content Header(navigation) on large screen */}
+                <Header text='Add a center' />
+
+                {/* Input form */}
+                <form class="mt-lg-5 mb-md-5">
+                  <div className="w-lg-50">
+                    <WarningAlert message={this.props.status.error} />
+                  </div>
+                  <div class="form-group row">
+                    <label for="name" class="col-sm-1 col-form-label">Name</label>
+                    <div class="col-sm-11">
+                      <input type="email"
+                        class="form-control w-lg-50"
+                        id="name"
+                        name="name"
+                        placeholder="The name of the center"
+                        onChange={this.getInput} />
+                      <small class="form-text text-muted">Less than 30 characters</small>
+                    </div>
+                  </div>
+                  <div class="form-group row">
+                    <label for="location" class="col-sm-1 col-form-label">Location</label>
+                    <div class="col-sm-11">
+                      <input type="text"
+                        class="form-control w-lg-50"
+                        id="location"
+                        name="location"
+                        placeholder="The location of the center"
+                        onChange={this.getInput} />
+                      <small class="form-text text-muted">Less than 30 characters</small>                        
+                    </div>
+                  </div>
+                  <div class="form-group row">
+                    <label for="description" class="col-sm-1 col-form-label">Details</label>
+                    <div class="col-sm-11">
+                      <textarea
+                        class="form-control w-lg-50"
+                        id="description" rows="7"
+                        name="description"
+                        placeholder="More details about the center"
+                        onChange={this.getInput}></textarea>
+                      <small class="form-text text-muted">Less than 200 characters</small>                        
+                    </div>
+                  </div>
+                  <div class="form-group row">
+                    <label for="capacity" class="col-sm-1 col-form-label">Capacity</label>
+                    <div class="col-sm-11">
+                      <input type="number"
+                        class="form-control w-lg-50"
+                        id="capacity"
+                        name="capacity"
+                        placeholder="How many seats"
+                        onChange={this.getInput} />
+                    </div>
+                  </div>
+                  <div class="form-group row">
+                    <label for="price" class="col-sm-1 col-form-label">Price</label>
+                    <div class="col-sm-11">
+                      <input type="number"
+                        class="form-control w-lg-50"
+                        id="price"
+                        name="price"
+                        placeholder="Price"
+                        onChange={this.getInput} />
+                    </div>
+                  </div>
+                  <fieldset class="form-group">
+                    <div className="row">
+                      <legend class="col-form-legend col-sm-1">Type</legend>
+                      <div class="col-sm-11 pt-2">
+                        <div class="form-check form-check-inline">
+                          <label class="form-check-label">
+                            <input type="radio"
+                              class="form-check-input"
+                              name="type"
+                              id="inlineRadio1"
+                              value="theater"
+                              onClick={this.getInput} /> Theater
+                          </label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                          <label class="form-check-label">
+                            <input type="radio"
+                              class="form-check-input"
+                              name="type"
+                              id="inlineRadio2"
+                              value="banquet"
+                              onClick={this.getInput} /> Banquet
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </fieldset>
+                  <div class="form-group row ">
+                    <label for="image" class="col-sm-1 col-form-label">Image</label>
+                    <div className="col-sm-11">
+                      <input type="file"
+                        class="form-control-file pt-2"
+                        id="image"
+                        name="image" />
+                    </div>
+                  </div>
+                  <div class="text-center w-25 pt-3">
+                    <a class="btn btn-outline-dark" onClick={this.add}>Add</a>
+                  </div>
+                </form>
+
+              </div>
+            </div>
+          </div>
+
+          <footer class="d-block d-sm-none mt-5">
+            <div class="container text-white text-center py-5">
+              <h1>Ievents</h1>
+              <p>Copyright &copy; 2017</p>
+            </div>
+          </footer>
+        </div>
+      );
+    }
+  }
+}

--- a/client/js/component/container/AddCenter.jsx
+++ b/client/js/component/container/AddCenter.jsx
@@ -4,6 +4,7 @@ import { Redirect } from 'react-router-dom';
 
 import { addCenter, clearStatus } from '../../actions/centerActions';
 
+import styles from '../../../sass/addCenter.scss';
 import UserSideNav from '../common/SideNavigation.jsx';
 import Header from '../common/Header.jsx';
 import { UserTopNav } from '../common/TopNavigation.jsx';

--- a/client/js/component/container/AddEvent.jsx
+++ b/client/js/component/container/AddEvent.jsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 import getAllCenters from '../../actions/centerActions';
 
 import addEventStyles from '../../../sass/addEvent.scss';
-import { UserSideNav } from '../common/SideNavigation.jsx';
+import UserSideNav from '../common/SideNavigation.jsx';
 import { UserTopNav } from '../common/TopNavigation.jsx';
 import CenterOptions from '../common/CenterDropDown.jsx';
 import Header from '../common/Header.jsx';

--- a/client/js/component/container/Centers2.jsx
+++ b/client/js/component/container/Centers2.jsx
@@ -6,7 +6,7 @@ import { showCenterModal } from '../../actions/centerActions';
 
 import styles from '../../../sass/centers2.scss';
 import { UserTopNav } from '../common/TopNavigation.jsx';
-import { UserSideNav } from '../common/SideNavigation.jsx';
+import UserSideNav from '../common/SideNavigation.jsx';
 import Header from '../common/Header.jsx';
 import CenterCards from '../common/CenterCards.jsx';
 import { CenterModal } from '../common/Modal';
@@ -26,6 +26,7 @@ import { CenterModal } from '../common/Modal';
       bookedOn: [],
       type: null,
     },
+    isAdmin: (store.user.user.role === 'admin') ? true : false,
   }
 })
 
@@ -90,7 +91,7 @@ export default class Centers2 extends React.Component {
                     {/* Centers  Grid*/}
                     <div className="mt-5">
                       <div className="row">
-                        <CenterCards centers={this.props.centers} btnAction={this.showModal}/>
+                        <CenterCards centers={this.props.centers} btnAction={this.showModal} isAdmin={this.props.isAdmin} />
                       </div>
                     </div>
                   </div>

--- a/client/js/component/container/EditEvent.jsx
+++ b/client/js/component/container/EditEvent.jsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 import getAllCenters from '../../actions/centerActions';
 
 import addEventStyles from '../../../sass/addEvent.scss';
-import { UserSideNav } from '../common/SideNavigation.jsx';
+import UserSideNav from '../common/SideNavigation.jsx';
 import { UserTopNav } from '../common/TopNavigation.jsx';
 import CenterOptions from '../common/CenterDropDown.jsx';
 import Header from '../common/Header.jsx';

--- a/client/js/component/container/Events.jsx
+++ b/client/js/component/container/Events.jsx
@@ -27,8 +27,8 @@ export default class Events extends React.Component {
     }
   }
 
-  // Getting all the events as soon as this component mount the DOM
-  componentDidMount() {
+  // Getting all the events as soon as this component is about to mount the DOM
+  componentWillMount() {
     this.props.dispatch(getAllEvents(this.props.user.token));
   }
 

--- a/client/js/component/container/Events.jsx
+++ b/client/js/component/container/Events.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import eventStyles from '../../../sass/userEvents.scss';
-import { UserSideNav } from '../common/SideNavigation.jsx';
+import UserSideNav from '../common/SideNavigation.jsx';
 import { UserTopNav } from '../common/TopNavigation.jsx';
 import { ConfirmModal } from '../common/Modal';
 import Header from '../common/Header.jsx';

--- a/client/js/component/container/index.jsx
+++ b/client/js/component/container/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import homeStyles from '../../../sass/home.scss';
 import TopNavigation from '../common/TopNavigation.jsx';
@@ -33,7 +34,7 @@ export default class Home extends React.Component {
                   </div>
                 </div>
               </div>
-              <a href="centers.html" class="btn btn-secondary mt-3">Checkout Our Centers</a>
+              <Link to="/centers1" class="btn btn-secondary mt-3">Checkout Our Centers</Link>
             </div>
           </div>
         </section>

--- a/client/js/index.jsx
+++ b/client/js/index.jsx
@@ -11,6 +11,7 @@ import Events from './component/container/Events.jsx';
 import EditEvent from './component/container/EditEvent.jsx';
 import Centers1 from './component/container/Centers1.jsx';
 import Centers2 from './component/container/Centers2.jsx';
+import AddCenter from './component/container/AddCenter.jsx';
 import Home from './component/container/index.jsx';
 
 const history = createBrowserHistory();
@@ -25,6 +26,7 @@ const App = () => {
       <Route exact path='/events' component={Events} />
       <Route exact path='/centers1' component={Centers1} />
       <Route exact path='/centers2' component={Centers2} />
+      <Route exact path='/addCenter' component={AddCenter} />
     </Switch>
   )
 }

--- a/client/js/reducers/centerReducers.js
+++ b/client/js/reducers/centerReducers.js
@@ -6,7 +6,13 @@ let initialState = {
   status: {
     fetching: false,
     fetched: false,
-    error: false,
+    fetchingError: false,
+    adding: false,
+    added: false,
+    addingError: false,
+    updating: false,
+    updated: false,
+    updatingError: false,
   },
 }
 
@@ -19,7 +25,7 @@ export default (state = initialState, action) => {
           ...state.status,
           fetching: true,
           fetched: false,
-          error: false
+          fetchingError: false
         },
       };
     }
@@ -32,7 +38,7 @@ export default (state = initialState, action) => {
           ...state.status,
           fetching: false,
           fetched: true,
-          error: false,
+          fetchingError: false,
         },
       };
     }
@@ -43,19 +49,58 @@ export default (state = initialState, action) => {
           ...state.status,
           fetching: false,
           fetched: false,
-          error: action.payload,
+          fetchingError: action.payload,
         },
       };
     }
+    case 'ADDING_CENTER': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          adding: true,
+          added: false,
+          addingError: false
+        },
+      };
+    }
+    case 'ADDING_CENTER_RESOLVED': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          adding: false,
+          added: true,
+          addingError: false,
+        },
+      }
+    }
+    case 'ADDING_CENTER_REJECTED': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          adding: false,
+          added: false,
+          addingError: action.payload,
+        },
+      }
+    }
     case 'SHOW_CENTER_MODAL': {
-      const modalContent = _.find(state.centers, {id: Number(action.payload)});
+      const modalContent = _.find(state.centers, { id: Number(action.payload) });
       return {
         ...state,
         modalContent: modalContent,
       }
     }
+    case 'CLEAR_STATUS': {
+      return {
+        ...state,
+        status: initialState.status,
+      }
+    }
     default: {
-      return state; 
+      return state;
     }
   }
 }

--- a/client/js/reducers/eventReducer.js
+++ b/client/js/reducers/eventReducer.js
@@ -66,11 +66,8 @@ export default (state = initialState, action) => {
       };
     }
     case 'ADDING_EVENT_RESOLVED': {
-      const { title, description, date, center } = action.payload.event;
-      const newEvent = { title, description, date, center };
       return {
         ...state,
-        events: [...state.events, newEvent],
         status: {
           ...state.status,
           adding: false,

--- a/client/sass/addCenter.scss
+++ b/client/sass/addCenter.scss
@@ -1,0 +1,92 @@
+$custom-black: rgba(0,0,0,0.9);
+$custom-blue: rgb(0, 142, 214);
+$background-color: #f6f7fa;
+
+body {
+  background-color: $background-color;
+  overflow-x: hidden; 
+}
+
+body > nav {
+  background-color: $custom-black;
+  border-bottom: 2px solid $custom-blue;
+}
+
+#navigation-section {
+  background-color: $custom-black;
+  min-height: 2000px;
+
+  .navigation-links {
+    a {
+      color: white;
+      font-weight: bold;
+    }
+  
+    .list-group-item {
+      background-color: transparent;
+      border-top: 1px solid $custom-blue;
+    }
+  
+    .list-group-item:last-child {
+      border-bottom: 1px solid $custom-blue;
+    }
+  }
+
+}
+
+#add-event-section {
+
+  nav {
+    background-color: $custom-black;
+  }
+  .dark-button {
+    background-color : $custom-black;
+    color: white;
+  }
+
+  form {
+    margin-top: 100px;
+  }
+}
+  
+#centers-section {
+  margin-top: 100px;
+
+  .search-box {
+    .btn {
+      color: white;
+      background-color: $custom-black;
+    }
+  }
+
+  .card {
+    margin: 5px;
+    .btn {
+      background-color: $custom-black !important;
+    }
+  }
+
+  .seat-badge {
+    position: absolute;
+    top: 50%;
+    left: 60%;
+    font-size: 20px;
+    background-color: rgba(0,0,0,0.4);
+  }
+  
+  .pagination {
+    a {
+      font-weight: bold;
+    }
+    .active {
+      a {
+        background-color: rgba(0,0,0,1);
+      }
+    }
+  }
+}
+  
+footer {
+  background-color: $custom-black;
+  border-top: 2px solid $custom-blue;
+}

--- a/client/sass/centers.scss
+++ b/client/sass/centers.scss
@@ -21,7 +21,8 @@ body > nav {
   }
 
   .card {
-
+    margin: 5px;
+    
     .card-img-top {
       height: 250px;
     }

--- a/client/sass/centers2.scss
+++ b/client/sass/centers2.scss
@@ -52,6 +52,8 @@ body > nav {
   }
 
   .card {
+    margin: 5px;
+    
     .btn {
       background-color: $custom-black !important;
     }

--- a/server/validation/centers.js
+++ b/server/validation/centers.js
@@ -16,7 +16,7 @@ export default {
       return 'center name cannot be empty';
     }
     if (name.length < 5 || name.length > 30) {
-      return 'center name must be between 5 and 25 characters';
+      return 'center name must be between 5 and 30 characters';
     }
     if (location && location.length > 30) {
       return 'center location must be below 30 characters';
@@ -44,7 +44,7 @@ export default {
     }
     return 'success';
   },
-  
+
   update(inputData) {
     const {
       name,

--- a/server/validation/centers.js
+++ b/server/validation/centers.js
@@ -18,13 +18,13 @@ export default {
     if (name.length < 5 || name.length > 30) {
       return 'center name must be between 5 and 25 characters';
     }
-    if (location !== undefined && location.length > 30) {
+    if (location && location.length > 30) {
       return 'center location must be below 30 characters';
     }
-    if (details !== undefined && details.length > 200) {
+    if (details && details.length > 200) {
       return 'center details must be below 200 characters';
     }
-    if (capacity !== undefined) {
+    if (capacity) {
       const noCapacity = Number(capacity);
       if (!Number.isFinite(noCapacity)) {
         return 'center capacity must be a number in string format';
@@ -44,6 +44,7 @@ export default {
     }
     return 'success';
   },
+  
   update(inputData) {
     const {
       name,


### PR DESCRIPTION
#### What does this PR do?
It uses react and redux to implement the add-center page
#### Description of Task to be completed?
User should be able to add a new center
#### How should this be manually tested?
- clone the repo
- cd into the project directory
- Run `npm install` to install all the dependency
- Run `npm run react:dev`
- visit the port where the webpack-dev-server started
- log in as an admin
- navigate to the add centers page
- try posting some centers
- when you get back to the centers page, those centers should be listed there.
#### Any background context you want to provide?
- The frontend still uses the locally hosted server, so you would have to create a .env file to fulfill all the needed environment variables, the run `npm run server:dev`
- Though the front end has an option for adding images, the image that you add won't reflect on the centers page and this is because I am yet to add the cloud image hosting service to help handle the image storage. The image that would be displayed would be the default image that I set when rendering the page.
- If you really want an image, you can do so by posting the link to an image when creating a center using just the API endpoint with an API testing tool.
#### What are the relevant pivotal tracker stories?
#152797380 
#### Screenshots (if appropriate)
![screencapture-localhost-8080-addcenter-1513008852113](https://user-images.githubusercontent.com/26048536/33840994-c54ecb1c-de96-11e7-804b-25b56e39d2a0.png)
#### Questions:
None