### PR TITLE
#153530271 Implement the delete transaction action with react

### DIFF
--- a/client/js/actions/transactionActions.js
+++ b/client/js/actions/transactionActions.js
@@ -55,6 +55,24 @@ export const allowTransaction = (userToken, id) => {
   }
 }
 
+export const deleteTransaction = (userToken, id) => {
+  return (dispatch) => {
+    dispatch({ type: 'DELETE_TRANSACTION' });
+    const config = {
+      headers: {
+        "access-token": userToken
+      }
+    };
+    axios.delete(`${apiBaseUrl}/transactions/${id}`, config)
+    .then((response) => {
+      dispatch({ type: 'DELETE_TRANSACTION_RESOLVED', payload: response.data, });
+    })
+    .catch((err) => {
+      dispatch({ type: 'DELETE_TRANSACTION_REJECTED', payload: err.response.data, });
+    });
+  }
+}
+
 export const clearTransactionStatus = () => {
   return { type: 'CLEAR_TRANSACTION_STATUS', }
 }

--- a/client/js/component/common/TransactionCards.jsx
+++ b/client/js/component/common/TransactionCards.jsx
@@ -135,11 +135,15 @@ const ActionButtons = (props) => {
     )
   } else {
     return (
-      <td className="text-center text-md-left text-lg-left pl-lg-4 pl-md-4">
-        <i
-          className="fa fa-trash fw fa-2x"
-          data-transaction-id={props.transactionId}          
-          onClick={props.onDelete}></i>
+      <td>
+        <span className="text-muted">{props.decision}</span>
+        <span className="d-block d-lg-inline d-md-inline ml-lg-2 ml-md-2 text-center">
+          <i
+            className="fa fa-trash fw"
+            data-transaction-id={props.transactionId}
+            onClick={props.onDelete}></i>
+        </span>
+
       </td>
     )
   }

--- a/client/js/component/common/TransactionCards.jsx
+++ b/client/js/component/common/TransactionCards.jsx
@@ -38,7 +38,8 @@ class TransactionCards extends React.Component {
                         transactions={center.transactions}
                         btnAction={this.showEventModal}
                         onAllow={this.props.onAllow}
-                        onCancel={this.props.onCancel} />
+                        onCancel={this.props.onCancel}
+                        onDelete={this.props.onDelete} />
                     </div>
                   </div>
                 </div>
@@ -82,7 +83,8 @@ const TransactionTable = (props) => {
                 decision={transaction.decision}
                 transactionId={transaction.id}
                 onAllow={props.onAllow}
-                onCancel={props.onCancel} />
+                onCancel={props.onCancel}
+                onDelete={props.onDelete} />
             </tr>
           ))
         }
@@ -133,8 +135,11 @@ const ActionButtons = (props) => {
     )
   } else {
     return (
-      <td>
-        Delete icon
+      <td className="text-center text-md-left text-lg-left pl-lg-4 pl-md-4">
+        <i
+          className="fa fa-trash fw fa-2x"
+          data-transaction-id={props.transactionId}          
+          onClick={props.onDelete}></i>
       </td>
     )
   }

--- a/client/js/component/container/Transactions.jsx
+++ b/client/js/component/container/Transactions.jsx
@@ -6,6 +6,7 @@ import {
   getAllTransactions,
   allowTransaction,
   cancelTransaction,
+  deleteTransaction,
   clearTransactionStatus
 } from '../../actions/transactionActions';
 
@@ -25,28 +26,32 @@ import { WarningAlert } from '../common/Alert';
 
 export default class Transactions extends React.Component {
   componentWillMount() {
-    const userToken = this.props.user.token;
-    this.props.dispatch(getAllTransactions(userToken));
+    this.props.dispatch(getAllTransactions(this.props.user.token));
+  }
+
+  refresh = () => {
+    this.props.dispatch(clearTransactionStatus());
+    this.props.dispatch(getAllTransactions(this.props.user.token));
   }
 
   componentDidUpdate() {
-    if (this.props.transactions.status.allowed || this.props.transactions.status.canceled) {
-      const userToken = this.props.user.token;
-      this.props.dispatch(clearTransactionStatus());
-      this.props.dispatch(getAllTransactions(userToken));
+    if (this.props.transactions.status.allowed ||
+      this.props.transactions.status.canceled ||
+      this.props.transactions.status.deleted) {
+      this.refresh();
     }
   }
 
   cancelTransaction = (e) => {
-    const userToken = this.props.user.token;
-    const transactionId = e.target.dataset.transactionId;
-    this.props.dispatch(cancelTransaction(userToken, transactionId));
+    this.props.dispatch(cancelTransaction(this.props.user.token, e.target.dataset.transactionId));
   }
 
   allowTransaction = (e) => {
-    const userToken = this.props.user.token;
-    const transactionId = e.target.dataset.transactionId;
-    this.props.dispatch(allowTransaction(userToken, transactionId));
+    this.props.dispatch(allowTransaction(this.props.user.token, e.target.dataset.transactionId));
+  }
+
+  deleteTransaction = (e) => {
+    this.props.dispatch(deleteTransaction(this.props.user.token, e.target.dataset.transactionId));
   }
 
   render() {
@@ -76,7 +81,8 @@ export default class Transactions extends React.Component {
                     <TransactionCards
                       centers={this.props.transactions.centers}
                       onCancel={this.cancelTransaction}
-                      onAllow={this.allowTransaction} />
+                      onAllow={this.allowTransaction}
+                      onDelete={this.deleteTransaction} />
                   </div>
                 </div>
               </div>

--- a/client/js/reducers/transactionReducer.js
+++ b/client/js/reducers/transactionReducer.js
@@ -124,6 +124,39 @@ export default (state = initialState, action) => {
         }
       }
     }
+    case 'DELETE_TRANSACTION': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          deleting: true,
+          deleted: false,
+          deletingError: false,
+        }
+      }
+    }
+    case 'DELETE_TRANSACTION_RESOLVED': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          deleting: false,
+          deleted: true,
+          deletingError: false,
+        }
+      }
+    }
+    case 'DELETE_TRANSACTION_REJECTED': {
+      return {
+        ...state,
+        status: {
+          ...state.status,
+          deleting: false,
+          deleted: false,
+          deletingError: action.payload,
+        }
+      }
+    }
     case 'CLEAR_TRANSACTION_STATUS': {
       return {
         ...state,


### PR DESCRIPTION
#### What does this PR do?
It uses react and redux to implement the delete transaction action
#### Description of Task to be completed?
User should be able to delete a transaction
#### How should this be manually tested?
- clone the repo
- cd into the project directory
- Run `npm install` to install all the dependency
- Run `npm run react:dev`
- visit the port where the webpack-dev-server started
- log in as an admin
- add some sample events
- navigate to the transactions page, all the transactions should be listed there categorized under the center the fall in
- after canceling or allowing any transaction, you should be able to delete them 
#### Any background context you want to provide?
- The frontend still uses the locally hosted server, so you would have to create a .env file to fulfill all the needed environment variables, then run `npm run server:dev` to start the server
#### What are the relevant pivotal tracker stories?
#153530271 
#### Screenshots (if appropriate)
None
#### Questions:
None